### PR TITLE
Arreglar gestió de temporades

### DIFF
--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -123,3 +123,7 @@ msgstr "SX3 (Emissió internacional)"
 msgctxt "#30027"
 msgid "Esport 3 (International broadcast)"
 msgstr "Esport 3 (Emissió internacional)"
+
+msgctxt "#30028"
+msgid "Season"
+msgstr "Temporada"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -123,3 +123,7 @@ msgstr "SX3 (International)"
 msgctxt "#30027"
 msgid "Esport 3 (International broadcast)"
 msgstr "Esport 3 (International)"
+
+msgctxt "#30028"
+msgid "Season"
+msgstr "Staffel"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -123,3 +123,7 @@ msgstr "SX3 (International broadcast)"
 msgctxt "#30027"
 msgid "Esport 3 (International broadcast)"
 msgstr "Esport 3 (International broadcast)"
+
+msgctxt "#30028"
+msgid "Season"
+msgstr "Season"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -123,3 +123,7 @@ msgstr "SX3 (Emisión internacional)"
 msgctxt "#30027"
 msgid "Esport 3 (International broadcast)"
 msgstr "Esport 3 (Emisión internacional)"
+
+msgctxt "#30028"
+msgid "Season"
+msgstr "Temporada"

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -123,3 +123,7 @@ msgstr "SX3 (Utland)"
 msgctxt "#30027"
 msgid "Esport 3 (International broadcast)"
 msgstr "Esport 3 (Utland)"
+
+msgctxt "#30028"
+msgid "Season"
+msgstr "Sesong"

--- a/resources/lib/tv3cat/TV3Strings.py
+++ b/resources/lib/tv3cat/TV3Strings.py
@@ -30,7 +30,8 @@ class TV3Strings(object):
             'tv3_int': 30024,
             'canal324_int': 30025,
             'c33super3_int': 30026,
-            'esport3_int': 30027
+            'esport3_int': 30027,
+            'temporada': 30028
         }
 
     def get(self, string):

--- a/resources/lib/utils/Urls.py
+++ b/resources/lib/utils/Urls.py
@@ -2,11 +2,14 @@
 
 url_base = 'https://www.3cat.cat/3cat/'
 url_coleccions = 'https://www.3cat.cat/3cat/tot-cataleg/tot/'
+url_capitols = 'https://www.3cat.cat/{}/capitols/'
 url_mesvist = 'http://www.ccma.cat/tv3/alacarta/mes-vist/'
+
+url_api_videos = 'https://api.3cat.cat/videos?version=2.0&_format=json&programatv_id={}&pagina={}&items_pagina={}&origen=auto&idioma=PU_CATALA&perfil=pc&tipus_contingut=PPD'
+url_api_videos_temporada = 'https://api.3cat.cat/videos?version=2.0&_format=json&programatv_id={}&pagina={}&items_pagina={}&ordre=capitol&origen=llistat&idioma=PU_CATALA&perfil=pc&tipus_contingut=PPD&temporada=PUTEMP_{}'
 
 url_directe_tv3 = 'https://directes3-tv-cat.3catdirectes.cat/live-content/tv3-hls/master.m3u8'
 url_directe_324 = 'https://directes-tv-int.3catdirectes.cat/live-content/canal324-hls/master.m3u8'
 url_directe_sx3 = 'https://directes-tv-cat.3catdirectes.cat/live-content/super3-hls/master.m3u8'
 url_directe_c33 = 'https://directes-tv-cat.3catdirectes.cat/live-content/c33-super3-hls/master.m3u8'
 url_directe_esport3 = 'https://directes-tv-cat.3catdirectes.cat/live-content/esport3-hls/master.m3u8'
-


### PR DESCRIPTION
Vaig obrir l'issue https://github.com/mcr222/plugin.video.3cat/issues/10. He estat mirant-ho més detingudament i he trobat alguns problemes que he intentat solucionar en aquest pedaç.

El problema amb l'està passant, que explique a l'issue, es deu en la meua opinió a que el plugin gestiona molt malament les temporades. En comptes de fer una consulta a l'API per esbrinar quantes temporades existeixen, el que fa és descarregar fins a 1000 capítols directament, i després recórrer-los una a un per a construir la llista de temporades.

Això causa diversos problemes
1. La consulta és feixuga i innecessària
2. Recórrer tota la llista de capítols és poc eficient
3. Quan un programa té més de 1000 capítols com l'Està Passant o el Telenotícies, el resutlat es desastrós perquè no es poden veure capítols recents
4. La llista de temporades reconstruïda no reflecteix la realitat del que després es pot trobar a la plataforma 3cat

Per exemple, a la plataforma hi ha dos tipus de programes, els que tenen temporades i els que no:

Amb temporades: https://www.3cat.cat/3cat/euforia/capitols/
Sense temporades: https://www.3cat.cat/3cat/esta-passant/capitols/

Es tracten de manera diferent:

- Per als que tenen temporada:
  - Hi apareix un filtre per seleccionar temporada.
  - Es descarreguen els primers 18 capítols de la temporada, en ordre ascendent: primer el que es va emetre primer.
  - En fer scroll, es descarreguen el següents capítols
- Per als que no tenen temporada:
  - El JSON no inclou la informació del filtre de temporada
  - Es descarreguen els darrers 18 capítols del programa, en ordre descendent: primer el que es s'ha emès el darrer

Això té sentit, per exemple, si tu vols veure la sèrie Nit i Dia, voldràs veure primer el capítol 1, després el 2, etc. Però per a programes diaris com el Telenotícies o l'està passant, el que vols el veure el capítol del dia anterior o alguns dels darrers dies.

Doncs bé, els canvis en aquest PR implementen exactament este comportament. Ara el camí que segueix l'usuari és el següent:

```
Col·leccions -> Lletra -> Programa -> Temporada -> Capítols de la temporada (Asc)
                                   \-> Darrers capítols (Desc)
```

A més, ara totes les pantalles tenen paginació, hi ha un enllaç per a passar a la pàgina següent, i el Kodi afegeix automàticament l'entrada `..` per tornar a l'anterior.

La consulta per obtindre el filtre de temporades és:

```
https://www.3cat.cat/3cat/{programaTitol}/capitols/
```

Les consultes per obtindre els capítols en sí són:

```
https://api.3cat.cat/videos?version=2.0&_format=json&programatv_id={}&pagina={}&items_pagina={}&origen=auto&idioma=PU_CATALA&perfil=pc&tipus_contingut=PPD
```
```
https://api.3cat.cat/videos?version=2.0&_format=json&programatv_id={}&pagina={}&items_pagina={}&ordre=capitol&origen=llistat&idioma=PU_CATALA&perfil=pc&tipus_contingut=PPD&temporada=PUTEMP_{}
```

Hi ha una excepció que he trobat, que és el Polònia. Este té temporades, i si selecciones una temporada antiga, els capítols estan ordenats de manera ascendent. En canvi, si agafes la temporada en curs, els capítols s'ordenen de manera descendent, el darrer primer.

Al PR això no ho tinc implementat, perquè utilitze una consulta fixa per als programes amb temporada i una per als que no. De manera que tots els comporten igual sense excepció. Una cosa que he vist és que cada programa inclou en el seu JSON la consulta pertinent per obtindre els capítols en l'ordre correcte, així que en realitat s'hauria d'utilitzar eixa consulta en comptes d'una de les dos fixes que jo utilitze, això arreglaria el cas del Polònia. Ho deixe per a un PR posterior.

**Nota sobre l'ús d'IA**

Realment tinc poca idea de Python així que m'he recolzat en la IA per a fer els canvis. Es possible que hi haja algun error de principiant en el codi.

El PR inclou dos commits:

- Afegir traducció: https://github.com/mcr222/plugin.video.3cat/commit/766d7b59e814763dc8096f1a49516663568d409d
  - Inclou la traducció de la paraula "Temporada" a llengües desconegudes com el castellà.
  - Aquest l'ha escrit completament l'IA Qwen Code, l'he posada com a coautora del commit perquè quede clar.
- La nova implementació de temporades: https://github.com/mcr222/plugin.video.3cat/commit/dca40fe08452a5b6f26eb7125f93067af824b5c0
  - Aquest l'he escrit jo, encara que com no tinc ni idea de Python, moltes sintaxis les he tret de l'IA també.
